### PR TITLE
remove `>` from first set of code in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 A sample data set for UpSet is included in the package and can be loaded like this:
 
 ```R
-> movies <- read.csv( system.file("extdata", "movies.csv", package = "UpSetR"), header=T, sep=";" )
-> mutations <- read.csv( system.file("extdata", "mutations.csv", package = "UpSetR"), header=T, sep = ",")
+movies <- read.csv( system.file("extdata", "movies.csv", package = "UpSetR"), header=T, sep=";" )
+mutations <- read.csv( system.file("extdata", "mutations.csv", package = "UpSetR"), header=T, sep = ",")
 ```
 
 The sample data set is a movie data set created by the [GroupLens Lab](http://grouplens.org/datasets/movielens) and curated by [Bilal Alsallakh](https://github.com/bilalsal).


### PR DESCRIPTION
minimal change to remove the `>` so a user can easily copy and paste the code or run directly from `Readme.me`