### PR TITLE
Highlight groups by providing a vector of colors for shading

### DIFF
--- a/R/Matrix.R
+++ b/R/Matrix.R
@@ -57,9 +57,11 @@ Create_layout <- function(setup, mat_color, mat_col){
 }
 
 ## Create data set to shade matrix 
-MakeShading <- function(Mat_data){
+MakeShading <- function(Mat_data, shade_color){
   y <- unique(Mat_data$y)
-  y <- (y[which(y %% 2 != 0)])
+  if(length(shade_color) == 1){
+    y <- (y[which(y %% 2 != 0)])
+  }
   data <- data.frame(cbind(y))
   data$min <- 0
   data$max <- (max(Mat_data$x) + 1)

--- a/R/upset.R
+++ b/R/upset.R
@@ -221,7 +221,7 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, set.metadata =
                                palette)
   }
   AllQueryData <- combineQueriesData(QInter_att_data, QElem_att_data, customAttDat, att.x, att.y)
-  ShadingData <- MakeShading(Matrix_layout)
+  ShadingData <- MakeShading(Matrix_layout, shade.color)
   Main_bar <- Make_main_bar(All_Freqs, Bar_Q, show.numbers, mb.ratio, customQBar, number.angles, EBar_data, mainbar.y.label,
                             mainbar.y.max)
   Matrix <- Make_matrix_plot(Matrix_layout, Set_sizes, All_Freqs, point.size, line.size,


### PR DESCRIPTION
First of all, thanks for this great package!

When comparing many sets, I faced the situation where it was hard to find the clustering of groups.
I, first highlighted the set bars by providing the colors according to the desired ranking using this kind of code
```
# count per filename, plus get the coloring right
count_df <- df %>%
  group_by(filename) %>%
  summarise(n = n()) %>%
  arrange(desc(n)) %>% # watch out! upset uses descending order
  separate(filename, c("cell", "exp"), sep = "_")
# get some colors
# first get named vector
cols <- setNames(brewer.pal(count_df$cell %>% unique() %>% length(),
                 name = "Set1"), count_df$cell %>% unique())
# second, revalue cell to get using the right order from arrange
mycols <- count_df %>%
  mutate(c = plyr::revalue(cell, cols)) %>%
  .$c
```
Using `sets.bar.color = mycols` helped, but I wanted to also have the shaded colors in line.
Since you shade only even rows, I proposed to allow `shade.color` to be a vector of colors.

Then the `upset` command becomes
```
upset(mat, nsets = 20, order.by = "freq", mb.ratio = c(0.3, 0.7), sets.bar.color = mycols, shade.color = mycols)
```
and gives this kind of result (I masked some unpublished names)

![rplot](https://cloud.githubusercontent.com/assets/710181/13597122/00ea3be6-e517-11e5-9134-17beca385096.png)
