### PR TITLE
Added an option to adjust axis font sizes

### DIFF
--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -61,7 +61,7 @@ Counter <- function(data, num_sets, start_col, name_of_sets, nintersections, mba
 
 ## Generate main bar plot
 Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_angles,
-                          ebar, ylabel, ymax, scale_intersections){
+                          ebar, ylabel, ymax, scale_intersections, font_scale){
   if(is.null(Q) == F){
     inter_data <- Q
     if(nrow(inter_data) != 0){
@@ -99,10 +99,10 @@ Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_an
                     + xlab(NULL) + ylab(ylabel) +labs(title = NULL)
                     + theme(panel.background = element_rect(fill = "white"),
                             plot.margin = unit(c(0.5,0.5,0.19,0.5), "lines"), panel.border = element_blank(),
-                            axis.title.y = element_text(vjust = -0.8, size = 8.3), axis.text.y = element_text(vjust=0.3,
-                                                                                                            size=7 )))
+                            axis.title.y = element_text(vjust = -0.8, size = 8.3*font_scale), axis.text.y = element_text(vjust=0.3,
+                                                                                                            size=7*font_scale )))
   if((show_num == "yes") || (show_num == "Yes")){
-    Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2, vjust = -1,
+    Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*font_scale, vjust = -1,
                                                 angle = number_angles, colour = Main_bar_data$color))
   }
   bInterDat <- NULL

--- a/R/SizeBar.R
+++ b/R/SizeBar.R
@@ -32,7 +32,7 @@ log2_reverse_trans <- function(){
 }
 
 ## Generate set size plot
-Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets, font_scale){
+Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets, font_scale, size_angle){
 #   if(ratios[1] < 0.4){
 #     m <- (-0.05)
 #   }
@@ -56,7 +56,7 @@ Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets
                 + theme(panel.background = element_rect(fill = "white"),
                         plot.margin=unit(c(-0.11,-1.3,0.5,0.5), "lines"),
                         axis.title.x = element_text(size = 8.3*font_scale),
-                        axis.text.x = element_text(size = 7*font_scale),
+                        axis.text.x = element_text(size = 7*font_scale, angle = size_angle, vjust = 1, hjust = 1),
                         axis.line = element_line(colour = "gray0"),
                         axis.line.y = element_blank(),
                         axis.line.x = element_line(colour = "gray0", size = 0.3),

--- a/R/SizeBar.R
+++ b/R/SizeBar.R
@@ -32,7 +32,7 @@ log2_reverse_trans <- function(){
 }
 
 ## Generate set size plot
-Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets){
+Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets, font_scale){
 #   if(ratios[1] < 0.4){
 #     m <- (-0.05)
 #   }
@@ -55,8 +55,8 @@ Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets
                                      expand = c(0,0))
                 + theme(panel.background = element_rect(fill = "white"),
                         plot.margin=unit(c(-0.11,-1.3,0.5,0.5), "lines"),
-                        axis.title.x = element_text(size = 8.3),
-                        axis.text.x = element_text(size = 7),
+                        axis.title.x = element_text(size = 8.3*font_scale),
+                        axis.text.x = element_text(size = 7*font_scale),
                         axis.line = element_line(colour = "gray0"),
                         axis.line.y = element_blank(),
                         axis.line.x = element_line(colour = "gray0", size = 0.3),

--- a/R/upset.R
+++ b/R/upset.R
@@ -50,7 +50,8 @@
 #'        a custom ggplots and the x and y aesthetics for the function. ncols is the number of columns that your ggplots should take up. See examples for how to add custom ggplots.
 #' @param scale.intersections The scale to be used for the intersection sizes. Options: "identity", "log10", "log2"
 #' @param scale.sets The scale to be used for the set sizes. Options: "identity", "log10", "log2"
-#' @param font.scale Value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)
+#' @param font.scale Numeric, value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)
+#' @param size.angle Numeric, angle to rotate the size bar x-axis text
 #' @details Visualization of set data in the layout described by Lex and Gehlenborg in \url{http://www.nature.com/nmeth/journal/v11/n8/abs/nmeth.3033.html}.
 #' UpSet also allows for visualization of queries on intersections and elements, along with custom queries queries implemented using
 #' Hadley Wickhams apply function. To further analyze the data contained in the intersections, the user may select additional attribute plots
@@ -118,7 +119,7 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
                   decreasing = c(T, F), show.numbers = "yes", number.angles = 0, group.by = "degree",cutoff = NULL,
                   queries = NULL, query.legend = "none", shade.color = "gray88", shade.alpha = 0.25, matrix.dot.alpha =0.5,
                   empty.intersections = NULL, color.pal = 1, boxplot.summary = NULL, attribute.plots = NULL, scale.intersections = "identity",
-                  scale.sets = "identity", font.scale = 1  ){
+                  scale.sets = "identity", font.scale = 1, size.angle = 0 ){
   
   startend <-FindStartEnd(data)
   first.col <- startend[1]
@@ -253,7 +254,7 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
                             mainbar.y.max, scale.intersections, font.scale)
   Matrix <- Make_matrix_plot(Matrix_layout, Set_sizes, All_Freqs, point.size, line.size,
                              name.size, labels, ShadingData, shade.alpha)
-  Sizes <- Make_size_plot(Set_sizes, sets.bar.color, mb.ratio, sets.x.label, scale.sets, font.scale)
+  Sizes <- Make_size_plot(Set_sizes, sets.bar.color, mb.ratio, sets.x.label, scale.sets, font.scale, size.angle)
   
   Make_base_plot(Main_bar, Matrix, Sizes, labels, mb.ratio, att.x, att.y, New_data,
                  expression, att.pos, first.col, att.color, AllQueryData, attribute.plots,

--- a/R/upset.R
+++ b/R/upset.R
@@ -50,6 +50,7 @@
 #'        a custom ggplots and the x and y aesthetics for the function. ncols is the number of columns that your ggplots should take up. See examples for how to add custom ggplots.
 #' @param scale.intersections The scale to be used for the intersection sizes. Options: "identity", "log10", "log2"
 #' @param scale.sets The scale to be used for the set sizes. Options: "identity", "log10", "log2"
+#' @param font.scale Value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)
 #' @details Visualization of set data in the layout described by Lex and Gehlenborg in \url{http://www.nature.com/nmeth/journal/v11/n8/abs/nmeth.3033.html}.
 #' UpSet also allows for visualization of queries on intersections and elements, along with custom queries queries implemented using
 #' Hadley Wickhams apply function. To further analyze the data contained in the intersections, the user may select additional attribute plots
@@ -117,7 +118,7 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
                   decreasing = c(T, F), show.numbers = "yes", number.angles = 0, group.by = "degree",cutoff = NULL,
                   queries = NULL, query.legend = "none", shade.color = "gray88", shade.alpha = 0.25, matrix.dot.alpha =0.5,
                   empty.intersections = NULL, color.pal = 1, boxplot.summary = NULL, attribute.plots = NULL, scale.intersections = "identity",
-                  scale.sets = "identity"){
+                  scale.sets = "identity", font.scale = 1  ){
   
   startend <-FindStartEnd(data)
   first.col <- startend[1]
@@ -249,10 +250,10 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
   ShadingData <- MakeShading(Matrix_layout, shade.color)
   }
   Main_bar <- Make_main_bar(All_Freqs, Bar_Q, show.numbers, mb.ratio, customQBar, number.angles, EBar_data, mainbar.y.label,
-                            mainbar.y.max, scale.intersections)
+                            mainbar.y.max, scale.intersections, font.scale)
   Matrix <- Make_matrix_plot(Matrix_layout, Set_sizes, All_Freqs, point.size, line.size,
                              name.size, labels, ShadingData, shade.alpha)
-  Sizes <- Make_size_plot(Set_sizes, sets.bar.color, mb.ratio, sets.x.label, scale.sets)
+  Sizes <- Make_size_plot(Set_sizes, sets.bar.color, mb.ratio, sets.x.label, scale.sets, font.scale)
   
   Make_base_plot(Main_bar, Matrix, Sizes, labels, mb.ratio, att.x, att.y, New_data,
                  expression, att.pos, first.col, att.color, AllQueryData, attribute.plots,

--- a/man/upset.Rd
+++ b/man/upset.Rd
@@ -17,7 +17,7 @@ upset(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F,
   matrix.dot.alpha = 0.5, empty.intersections = NULL, color.pal = 1,
   boxplot.summary = NULL, attribute.plots = NULL,
   scale.intersections = "identity", scale.sets = "identity",
-  font.scale = 1)
+  font.scale = 1, size.angle = 0)
 }
 \arguments{
 \item{data}{Data set}
@@ -106,7 +106,9 @@ a custom ggplots and the x and y aesthetics for the function. ncols is the numbe
 
 \item{scale.sets}{The scale to be used for the set sizes. Options: "identity", "log10", "log2"}
 
-\item{font.scale}{Value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)}
+\item{font.scale}{Numeric, value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)}
+
+\item{size.angle}{Numeric, angle to rotate the size bar x-axis text}
 }
 \description{
 Visualization of set intersections using novel UpSet matrix design.

--- a/man/upset.Rd
+++ b/man/upset.Rd
@@ -16,7 +16,8 @@ upset(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F,
   query.legend = "none", shade.color = "gray88", shade.alpha = 0.25,
   matrix.dot.alpha = 0.5, empty.intersections = NULL, color.pal = 1,
   boxplot.summary = NULL, attribute.plots = NULL,
-  scale.intersections = "identity", scale.sets = "identity")
+  scale.intersections = "identity", scale.sets = "identity",
+  font.scale = 1)
 }
 \arguments{
 \item{data}{Data set}
@@ -104,6 +105,8 @@ a custom ggplots and the x and y aesthetics for the function. ncols is the numbe
 \item{scale.intersections}{The scale to be used for the intersection sizes. Options: "identity", "log10", "log2"}
 
 \item{scale.sets}{The scale to be used for the set sizes. Options: "identity", "log10", "log2"}
+
+\item{font.scale}{Value to scale the font sizes, applies to the y-axis of the main bar plot, the x-axis of the set size plot, and the numbers above the intersection size bars (if present)}
 }
 \description{
 Visualization of set intersections using novel UpSet matrix design.


### PR DESCRIPTION
I've added an option in the main `upset()` function to allow relative adjustment of the font sizes in the main bar plot as well as the set size plot.  The `font.scale` option will scale the default values by the corresponding amount, with a default value of 1 (no scaling).  Also added an option to rotate the size bar plot x-axis text.

This change was originally done for my own use but I thought it might be useful to others as well.  

I should note as well that I've updated the documentation to reflect this new parameter