### PR TITLE
Introduces title to plots (closes #76)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Release v1.4.1
+
+- Allow plot title with specified size and position (@jonocarroll, #76)
+
 Release v1.4.0
 
 - Allow custom y-axis label and scale

--- a/R/upset.R
+++ b/R/upset.R
@@ -9,6 +9,8 @@
 #' @param set.metadata Metadata that offers insight to an attribute of the sets. Input should be a data frame where the first column is set names, and the
 #'        remaining columns are attributes of those sets. To learn how to use this parameter it is highly suggested to view the set metadata vignette. The link
 #'        can be found on the package's GitHub page.
+#' @param title Plot title 
+#' @param title.pos Position of title in grid reference as a named vector. Default \code{c(x=0.65, y=0.95)}.
 #' @param intersections Specific intersections to include in plot entered as a list of lists.
 #'        Ex: list(list("Set name1", "Set name2"), list("Set name1", "Set name3")). If data is entered into this parameter the only data shown on the UpSet plot
 #'        will be the specific intersections listed.
@@ -95,6 +97,10 @@
 #' upset(movies, nsets = 7, nintersects = 30, mb.ratio = c(0.5, 0.5),
 #'       order.by = c("freq", "degree"), decreasing = c(TRUE,FALSE))
 #'
+# upset(movies, nsets = 7, nintersects = 30, mb.ratio = c(0.5, 0.5),
+#       order.by = c("freq", "degree"), decreasing = c(TRUE,FALSE),
+#       title = "Movies", title.pos = c(x = 0.1, y = 0.95))
+#'
 #' upset(movies, sets = c("Drama", "Comedy", "Action", "Thriller", "Western", "Documentary"),
 #'       queries = list(list(query = intersects, params = list("Drama", "Action")),
 #'                 list(query = between, params = list(1970, 1980), color = "red", active = TRUE)))
@@ -113,7 +119,7 @@
 #' @import grDevices
 #' @import scales
 #' @export
-upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F, set.metadata = NULL, intersections = NULL,
+upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F, set.metadata = NULL, title = "", title.pos = c(x = 0.65, y = 0.95), intersections = NULL,
                   matrix.color = "gray23", main.bar.color = "gray23", mainbar.y.label = "Intersection Size", mainbar.y.max = NULL,
                   sets.bar.color = "gray23", sets.x.label = "Set Size", point.size = 2.2, line.size = 0.7,
                   mb.ratio = c(0.70,0.30), expression = NULL, att.pos = NULL, att.color = main.bar.color, order.by = c("freq", "degree"),
@@ -135,6 +141,10 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
                  "#CC79A7")
   }
 
+  ## ensure title.pos is conformant
+  if (!is.numeric(title.pos)) stop("title.pos must be numeric")
+  if (!identical(sort(names(title.pos)), c("x", "y"))) stop("title.pos requires a named vector with components 'x' and 'y'")
+  
   if(is.null(intersections) == F){
     Set_names <- unique((unlist(intersections)))
     Sets_to_remove <- Remove(data, first.col, last.col, Set_names)
@@ -280,6 +290,9 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
       AllQueryData = AllQueryData,
       attribute.plots = attribute.plots,
       legend = legend,
+      title = title,
+      title.pos = title.pos,
+      text.scale = text.scale,
       query.legend = query.legend,
       BoxPlots = BoxPlots,
       Set_names = Set_names,
@@ -311,6 +324,7 @@ print.upset <- function(x, newpage = TRUE) {
     set_metadata = x$set.metadata,
     set_metadata_plots = x$set.metadata.plots,
     newpage = newpage)
+  grid::grid.text(x$title, x = x$title.pos[["x"]], y = x$title.pos[["y"]], gp = grid::gpar(fontsize = 16*x$text.scale))
 }
 
 #' @export

--- a/man/upset.Rd
+++ b/man/upset.Rd
@@ -5,7 +5,8 @@
 \title{UpSetR Plot}
 \usage{
 upset(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F,
-  set.metadata = NULL, intersections = NULL, matrix.color = "gray23",
+  set.metadata = NULL, title = "", title.pos = c(x = 0.65, y = 0.95),
+  intersections = NULL, matrix.color = "gray23",
   main.bar.color = "gray23", mainbar.y.label = "Intersection Size",
   mainbar.y.max = NULL, sets.bar.color = "gray23",
   sets.x.label = "Set Size", point.size = 2.2, line.size = 0.7,
@@ -30,9 +31,13 @@ upset(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F,
 
 \item{keep.order}{Keep sets in the order entered using the sets parameter. The default is FALSE, which orders the sets by their sizes.}
 
-\item{set.metadata}{Metadata that offers insight to an attribute of the sets. Input should be a data frame where the first column is set names, and the 
+\item{set.metadata}{Metadata that offers insight to an attribute of the sets. Input should be a data frame where the first column is set names, and the
 remaining columns are attributes of those sets. To learn how to use this parameter it is highly suggested to view the set metadata vignette. The link
 can be found on the package's GitHub page.}
+
+\item{title}{Plot title}
+
+\item{title.pos}{Position of title in grid reference as a named vector. Default \code{c(x=0.65, y=0.95)}.}
 
 \item{intersections}{Specific intersections to include in plot entered as a list of lists.
 Ex: list(list("Set name1", "Set name2"), list("Set name1", "Set name3")). If data is entered into this parameter the only data shown on the UpSet plot
@@ -156,6 +161,7 @@ attributeplots <- list(gridrows = 55,
 upset(movies, nsets = 7, nintersects = 30, mb.ratio = c(0.5, 0.5),
       order.by = c("freq", "degree"), decreasing = c(TRUE,FALSE))
 
+
 upset(movies, sets = c("Drama", "Comedy", "Action", "Thriller", "Western", "Documentary"),
       queries = list(list(query = intersects, params = list("Drama", "Action")),
                 list(query = between, params = list(1970, 1980), color = "red", active = TRUE)))
@@ -165,7 +171,7 @@ upset(movies, attribute.plots = attributeplots,
                     list(query = intersects, params = list("Drama"), color= "red"),
                     list(query = elements, params = list("ReleaseDate", 1990, 1991, 1992))),
       main.bar.color = "yellow")
-      
+
 }
 \references{
 Lex et al. (2014). UpSet: Visualization of Intersecting Sets


### PR DESCRIPTION
- updated NEWS
- minor differences in upset.Rd likely due to different roxygen versions
- NAMESPACE changes (not committed) likely due to roxygen versions/out of date build

Adds `title` and `title.pos` arguments to `upset`, with respective defaults `""` and `c(x=0.65, y=0.95)` (above the main plot components). No impact to plot when not used (plots the empty string as text) but the call to `grid.text` _could_ be avoided entirely if you require.

Example:

``` r
library(UpSetR)
movies <- read.csv( system.file("extdata", "movies.csv", package = "UpSetR"), header=TRUE, sep=";" )
upset(movies, nsets = 7, nintersects = 30, mb.ratio = c(0.5, 0.5),
      order.by = c("freq", "degree"), decreasing = c(TRUE,FALSE), 
      title = "Movies", title.pos = c(x = 0.1, y = 0.95))
```

![](https://i.imgur.com/Pv69QrJ.png)