### PR TITLE
Allow zero-only columns in FindStartEnd

### DIFF
--- a/R/Helper.funcs.R
+++ b/R/Helper.funcs.R
@@ -8,7 +8,7 @@ FindStartEnd <- function(data){
       startend[1] <- i
       break
     }
-    else if((column[1] == "1") && (length(column) == 1)){
+    else if((column[1] %in% c("0","1")) && (length(column) == 1)){
       startend[1] <- i
       break
     }
@@ -27,7 +27,7 @@ FindStartEnd <- function(data){
       startend[2] <- i
       break
     }
-    else if((column[1] == "1") && (length(column) == 1)){
+    else if((column[1] %in% c("0","1")) && (length(column) == 1)){
       startend[2] <- i
       break
     }


### PR DESCRIPTION
When trying to generate plots where zero-only sets are included by specifying the sets explicitly (`sets=[...]`), `upset()` fails if the first or last column contain only zeros.

The attached patch for the `FindStartEnd` heuristic fixes this behavior for me, I'm not sure whether this breaks other use cases though.