### PR TITLE
Vectorize to increase speed of Counter().

### DIFF
--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -45,10 +45,8 @@ Counter <- function(data, num_sets, start_col, name_of_sets, nintersections, mba
   #delete rows used to order data correctly. Not needed to set up bars.
   delete_row <- (num_sets + 2)
   Freqs <- Freqs[ , -delete_row]
-  for( i in 1:nrow(Freqs)){
-    Freqs$x[i] <- i
-    Freqs$color <- mbar_color
-  }
+  Freqs$x <- 1:nrow(Freqs)
+  Freqs$color <- mbar_color
   if(is.na(nintersections)){
     nintersections = nrow(Freqs)
   }

--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -26,9 +26,7 @@ Counter <- function(data, num_sets, start_col, name_of_sets, nintersections, mba
   Freqs <- Freqs[!(rowSums(Freqs[ ,1:num_sets]) == 0), ]
   #Aggregation by degree
   if(tolower(aggregate) == "degree"){
-    for(i in 1:nrow(Freqs)){
-      Freqs$degree[i] <- rowSums(Freqs[ i ,1:num_sets])
-    }
+    Freqs$degree <- rowSums(Freqs[, 1:num_sets])
     order_cols <- c()
     for(i in 1:length(order_mat)){
       order_cols[i] <- match(order_mat[i], colnames(Freqs))

--- a/R/Specific.intersections.R
+++ b/R/Specific.intersections.R
@@ -54,10 +54,8 @@ specific_intersections <- function(data, first.col, last.col, intersections, ord
   #delete rows used to order data correctly. Not needed to set up bars.
   delete_row <- (num_sets + 2)
   Freqs <- Freqs[ , -delete_row]
-  for( i in 1:nrow(Freqs)){
-    Freqs$x[i] <- i
-    Freqs$color <- mbar_color
-  }
+  Freqs$x <- 1:nrow(Freqs)
+  Freqs$color <- mbar_color
   Freqs <- na.omit(Freqs)
   return(Freqs)
 }


### PR DESCRIPTION
Thanks for the great package. My colleagues and I find UpSet plots very useful.

For one of our larger data sets, we observed that `upset()` takes ~5 seconds to complete. After profiling, we found that the following lines contribute the large majority of this compute time (~3 seconds).

https://github.com/hms-dbmi/UpSetR/blob/df2151f3e9c585ed95c4bdbb47ff2f57e5ea8c01/R/MainBar.R#L29-L31

In this PR, I converted the above to:

```
Freqs$degree <- rowSums(Freqs[, 1:num_sets])
```

This reduced the runtime of `upset()` to ~2 seconds.

The results should be identical, but to test I ran the following example code from `?upset`:

```
movies <- read.csv(system.file("extdata", "movies.csv", package = "UpSetR"),
                   header=TRUE, sep=";" )
upset(movies, nsets = 7, nintersects = 30, mb.ratio = c(0.5, 0.5),
      order.by = c("freq", "degree"), decreasing = c(TRUE,FALSE))
```

**Before:**

![image](https://user-images.githubusercontent.com/1608317/104373699-c93b7a00-54ee-11eb-9a94-52135784a391.png)


**After:**

![image](https://user-images.githubusercontent.com/1608317/104373018-516d4f80-54ee-11eb-8075-fa5cfe3f4e70.png)
