### PR TITLE
By default, exclude specific intersections that have size = 0

### DIFF
--- a/R/upset.R
+++ b/R/upset.R
@@ -149,6 +149,17 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
     }
     All_Freqs <- specific_intersections(data, first.col, last.col, intersections, order.by, group.by, decreasing,
                                         cutoff, main.bar.color, Set_names)
+    if (is.null(empty.intersections) == T){ #change to a minimum size integer?
+      All_Freqs <- All_Freqs[All_Freqs$freq>0,]
+      All_Freqs <- All_Freqs[,colSums(All_Freqs[All_Freqs$freq>0,-length(All_Freqs)])>0]
+      #repeat remove with new filtered Set names
+      Set_names <- colnames(head(All_Freqs[,(-length(All_Freqs)+2):-length(All_Freqs)]))
+      Sets_to_remove <- Remove(data, first.col, last.col, Set_names)
+      New_data <- Wanted(data, Sets_to_remove)
+      Num_of_set <- Number_of_sets(Set_names)
+    }
+
+
   }
   else if(is.null(intersections) == T){
     Set_names <- sets


### PR DESCRIPTION
This helps when dealing with a big dataset, where you might wish to select all intersections with one Set but not others. 

small code example for all 2 by 2 combinations with myTargetSet:

c2<-combn(names( MySetList ) ,2)[,grep("myTargetSet",combn(names( MySetList ),2)[1,])]
list_of_lists <- apply(t(c2),1,list) )

upset(fromList(ortholist) ,nsets = 81, nintersects=100
      ,queries= list(list (query = elements , 
                         params = list( "myTargetSet" ), color= "red" ,active = T) )  
      ,intersections = c(list( list( "myTargetSet" ) ),list_of_lists)
       )