### PR TITLE
Add a possibility to allow the universal empty set

### DIFF
--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -3,7 +3,7 @@
 ## Counts the frequency of each intersection being looked at and sets up data for main bar plot.
 ## Also orders the data for the bar plot and matrix plot
 Counter <- function(data, num_sets, start_col, name_of_sets, nintersections, mbar_color, order_mat,
-                    aggregate, cut, empty_intersects, decrease){
+                    aggregate, cut, empty_intersects, decrease, keep.universal.empty.set = FALSE){
   temp_data <- list()
   Freqs <- data.frame()
   end_col <- as.numeric(((start_col + num_sets) -1))
@@ -22,8 +22,12 @@ Counter <- function(data, num_sets, start_col, name_of_sets, nintersections, mba
     all <- rbind(Freqs, empty)
     Freqs <- data.frame(all[!duplicated(all[1:num_sets]), ], check.names = F)
   }
-  #Remove universal empty set
-  Freqs <- Freqs[!(rowSums(Freqs[ ,1:num_sets]) == 0), ]
+  
+  if (!keep.universal.empty.set){
+    # Remove universal empty set
+    Freqs <- Freqs[!(rowSums(Freqs[ ,1:num_sets]) == 0), ]
+  }
+  
   #Aggregation by degree
   if(tolower(aggregate) == "degree"){
     for(i in 1:nrow(Freqs)){

--- a/R/upset.R
+++ b/R/upset.R
@@ -42,6 +42,7 @@
 #' @param shade.alpha Transparency of shading in matrix
 #' @param matrix.dot.alpha Transparency of the empty intersections points in the matrix
 #' @param empty.intersections Additionally display empty sets up to nintersects
+#' @param keep.universal.empty.set Additionally displays the universal empty set (i.e. the set \code{c()} for which no choices are selected)
 #' @param color.pal Color palette for attribute plots
 #' @param boxplot.summary Boxplots representing the distribution of a selected attribute for each intersection. Select attributes by entering a character vector of attribute names (e.g. c("Name1", "Name2")).
 #'        The maximum number of attributes that can be entered is 2.
@@ -123,7 +124,7 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
                   mb.ratio = c(0.70,0.30), expression = NULL, att.pos = NULL, att.color = main.bar.color, order.by = c("freq", "degree"),
                   decreasing = c(T, F), show.numbers = "yes", number.angles = 0, number.colors=NULL, group.by = "degree",cutoff = NULL,
                   queries = NULL, query.legend = "none", shade.color = "gray88", shade.alpha = 0.25, matrix.dot.alpha =0.5,
-                  empty.intersections = NULL, color.pal = 1, boxplot.summary = NULL, attribute.plots = NULL, scale.intersections = "identity",
+                  empty.intersections = NULL, keep.universal.empty.set = FALSE, color.pal = 1, boxplot.summary = NULL, attribute.plots = NULL, scale.intersections = "identity",
                   scale.sets = "identity", text.scale = 1, set_size.angles = 0 , set_size.show = FALSE, set_size.numbers_size = NULL, set_size.scale_max = NULL){
 
   startend <-FindStartEnd(data)
@@ -162,7 +163,8 @@ upset <- function(data, nsets = 5, nintersects = 40, sets = NULL, keep.order = F
     Set_names <- order_sets(New_data, Set_names)
     }
     All_Freqs <- Counter(New_data, Num_of_set, first.col, Set_names, nintersects, main.bar.color,
-                         order.by, group.by, cutoff, empty.intersections, decreasing)
+                         order.by, group.by, cutoff, empty.intersections, decreasing,
+                         keep.universal.empty.set = keep.universal.empty.set)
   }
   Matrix_setup <- Create_matrix(All_Freqs)
   labels <- Make_labels(Matrix_setup)

--- a/man/upset.Rd
+++ b/man/upset.Rd
@@ -38,6 +38,7 @@ upset(
   shade.alpha = 0.25,
   matrix.dot.alpha = 0.5,
   empty.intersections = NULL,
+  keep.universal.empty.set = FALSE,
   color.pal = 1,
   boxplot.summary = NULL,
   attribute.plots = NULL,
@@ -124,6 +125,8 @@ See examples section on how to do this.}
 \item{matrix.dot.alpha}{Transparency of the empty intersections points in the matrix}
 
 \item{empty.intersections}{Additionally display empty sets up to nintersects}
+
+\item{keep.universal.empty.set}{Additionally displays the universal empty set (i.e. the set \code{c()} for which no choices are selected)}
 
 \item{color.pal}{Color palette for attribute plots}
 


### PR DESCRIPTION
Thanks for this package, it is very helpful!

In my application, it is also of interest to allow the universal empty set (i.e. if some rows of the dataset have no answer selected).

This PR adds a new option `keep.universal.empty.set` which is `FALSE` by default (to be back-compatible).
When `keep.universal.empty.set = TRUE`, the output graph also includes the universal empty set as well as all the other sets that have been chosen, as usual.