### PR TITLE
Do not add line to combination matrix if line.size == 0

### DIFF
--- a/R/Matrix.R
+++ b/R/Matrix.R
@@ -104,9 +104,13 @@ Make_matrix_plot <- function(Mat_data,Set_size_data, Main_bar_data, point_size, 
                               fill = shading_data$shade_color, alpha = shade_alpha)
                   + geom_point(data= Mat_data, aes_string(x= "x", y= "y"), colour = Mat_data$color,
                                size= point_size, alpha = Mat_data$alpha, shape=16)
-                  + geom_line(data= Mat_data, aes_string(group = "Intersection", x="x", y="y",
-                                                         colour = "color"), size = line_size)
                   + scale_color_identity())
+  # add line conditionally
+  if(line_size > 0) {
+    Matrix_plot <- Matrix_plot +
+      geom_line(data= Mat_data, aes_string(group = "Intersection", x="x", y="y",
+                                           colour = "color"), size = line_size)
+  }
   Matrix_plot <- ggplot_gtable(ggplot_build(Matrix_plot))
   return(Matrix_plot)
 }


### PR DESCRIPTION
Setting `line.size` to zero does not eliminate the line from the combination matrix. This change gives us a way of disabling the lines from the combination matrix by setting `line.size` to zero.