### PR TITLE
A collection of changes for visual improvements

### DIFF
--- a/R/Boxplot.R
+++ b/R/Boxplot.R
@@ -40,18 +40,18 @@ BoxPlotsPlot <- function(bdat, att, att_color){
   upper_xlim <- as.numeric((max(bdat$x) + 1))
   plot_lims <- as.numeric(0:upper_xlim)
   bdat$x <- as.factor(bdat$x)
-  boxplots <- ggplotGrob(ggplot()
-                         + theme_bw() +ylab(yaxis)
-                         + scale_x_discrete(limits = plot_lims, expand = c(0,0))
-                         + theme(plot.margin = unit(c(-0.7,0,0,0), "cm"),
-                                 axis.title.y = element_text(vjust = -0.8),
-                                 axis.ticks.x = element_blank(),
-                                 axis.text.x = element_blank(),
-                                 panel.border = element_blank(),
-                                 panel.grid.minor = element_blank(),
-                                 panel.grid.major = element_blank(),
-                                 axis.title.x = element_blank())
-                         + geom_boxplot(data = bdat, aes_string(x="x", y="attribute"),
-                                        fill = att_color, colour = "gray80"))
+  boxplots <- ggplotGrob(ggplot() +
+                         theme_bw() + ylab(yaxis) +
+                         scale_x_discrete(limits = plot_lims, expand = c(0,0)) +
+                         theme(plot.margin = unit(c(-0.7,0,0,0), "cm"),
+                               axis.title.y = element_text(vjust = -0.8),
+                               axis.ticks.x = element_blank(),
+                               axis.text.x = element_blank(),
+                               panel.border = element_blank(),
+                               panel.grid.minor = element_blank(),
+                               panel.grid.major = element_blank(),
+                               axis.title.x = element_blank()) +
+                         geom_boxplot(data = bdat, aes(x = .data[["x"]], y = .data[["attribute"]]),
+                                      linewidth = 0.3, fill = att_color, colour = "gray80"))
   return(boxplots)
 }

--- a/R/Boxplot.R
+++ b/R/Boxplot.R
@@ -38,7 +38,7 @@ BoxPlotsPlot <- function(bdat, att, att_color){
   col <- match(att, colnames(bdat))
   colnames(bdat)[col] <- "attribute"
   upper_xlim <- as.numeric((max(bdat$x) + 1))
-  plot_lims <- as.numeric(0:upper_xlim)
+  plot_lims <- as.factor(0:upper_xlim)
   bdat$x <- as.factor(bdat$x)
   boxplots <- ggplotGrob(ggplot() +
                          theme_bw() + ylab(yaxis) +

--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -115,18 +115,16 @@ Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_an
     Main_bar_data$freq <- round(log10(Main_bar_data$freq), 2)
     ymax <- log10(ymax)
   }
-  Main_bar_plot <- (ggplot(data = Main_bar_data, aes_string(x = "x", y = "freq")) 
-                    + scale_y_continuous(trans = scale_intersections)
-                    + ylim(0, ymax)
-                    + geom_bar(stat = "identity", width = 0.6,
-                               fill = Main_bar_data$color)
-                    + scale_x_continuous(limits = c(0,(nrow(Main_bar_data)+1 )), expand = c(0,0),
-                                         breaks = NULL)
-                    + xlab(NULL) + ylab(ylabel) +labs(title = NULL)
-                    + theme(panel.background = element_rect(fill = "white"),
-                            plot.margin = unit(c(0.5,0.5,bottom_margin,0.5), "lines"), panel.border = element_blank(),
-                            axis.title.y = element_text(vjust = -0.8, size = 8.3*y_axis_title_scale), axis.text.y = element_text(vjust=0.3,
-                                                                                                            size=7*y_axis_tick_label_scale)))
+  Main_bar_plot <- (ggplot(data = Main_bar_data, aes(x = .data[["x"]], y = .data[["freq"]])) +
+                    scale_y_continuous(trans = scale_intersections) +
+                    ylim(0, ymax) +
+                    geom_bar(stat = "identity", width = 0.6, fill = Main_bar_data$color) +
+                    scale_x_continuous(limits = c(0,(nrow(Main_bar_data)+1 )), expand = c(0,0), breaks = NULL) +
+                    xlab(NULL) + ylab(ylabel) + labs(title = NULL) +
+                    theme(panel.background = element_rect(fill = "white"),
+                          plot.margin = unit(c(0.5,0.5,bottom_margin,0.5), "lines"), panel.border = element_blank(),
+                          axis.title.y = element_text(vjust = -0.8, size = 8.3*y_axis_title_scale), 
+			  axis.text.y = element_text(vjust=0.3, size=7*y_axis_tick_label_scale)))
   if((show_num == "yes") || (show_num == "Yes")){
     number_vjust <- number_hjust <- 0.5 # ggplot2 defaults
     if(number_angles == 0) {
@@ -139,11 +137,11 @@ Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_an
       number_hjust <- -0.2
     }
     if(is.null(number.colors)) {
-      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale,
+      Main_bar_plot <- (Main_bar_plot + geom_text(aes(label = .data[["freq"]]), size = 2.2*intersection_size_number_scale,
 						  vjust = number_vjust, hjust = number_hjust,
                                                   angle = number_angles, colour = Main_bar_data$color))
     } else {
-      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale,
+      Main_bar_plot <- (Main_bar_plot + geom_text(aes(label = .data[["freq"]]), size = 2.2*intersection_size_number_scale,
 						  vjust = number_vjust, hjust = number_hjust,
                                                   angle = number_angles, colour = number.colors))
     }
@@ -171,33 +169,31 @@ Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_an
     bCustomDat <- bCustomDat[order(bCustomDat$x), ]
   }
   if(length(bInterDat) != 0){
-    Main_bar_plot <- Main_bar_plot + geom_bar(data = bInterDat,
-                                              aes_string(x="x", y = "freq"),
+    Main_bar_plot <- Main_bar_plot + geom_bar(data = bInterDat, aes(x = .data[["x"]], y = .data[["freq"]]),
                                               fill = bInterDat$color,
                                               stat = "identity", position = "identity", width = 0.6)
   }
   if(length(bElemDat) != 0){
-    Main_bar_plot <- Main_bar_plot + geom_bar(data = bElemDat,
-                                              aes_string(x="x", y = "freq"),
+    Main_bar_plot <- Main_bar_plot + geom_bar(data = bElemDat, aes(x = .data[["x"]], y = .data[["freq"]]),
                                               fill = bElemDat$color,
                                               stat = "identity", position = "identity", width = 0.6)
   }
   if(length(bCustomDat) != 0){
-    Main_bar_plot <- (Main_bar_plot + geom_bar(data = bCustomDat, aes_string(x="x", y = "freq2"),
+    Main_bar_plot <- (Main_bar_plot + geom_bar(data = bCustomDat, aes(x = .data[["x"]], y = .data[["freq2"]]),
                                                fill = bCustomDat$color2,
                                                stat = "identity", position ="identity", width = 0.6))
   }
   if(length(pCustomDat) != 0){
-    Main_bar_plot <- (Main_bar_plot + geom_point(data = pCustomDat, aes_string(x="x", y = "freq2"), colour = pCustomDat$color2,
+    Main_bar_plot <- (Main_bar_plot + geom_point(data = pCustomDat, aes(x = .data[["x"]], y = .data[["freq2"]]), colour = pCustomDat$color2,
                                                  size = 2, shape = 17, position = position_jitter(width = 0.2, height = 0.2)))
   }
   if(length(pInterDat) != 0){
-    Main_bar_plot <- (Main_bar_plot + geom_point(data = pInterDat, aes_string(x="x", y = "freq"),
+    Main_bar_plot <- (Main_bar_plot + geom_point(data = pInterDat, aes(x = .data[["x"]], y = .data[["freq"]]),
                                                  position = position_jitter(width = 0.2, height = 0.2),
                                                  colour = pInterDat$color, size = 2, shape = 17))
   }
   if(length(pElemDat) != 0){
-    Main_bar_plot <- (Main_bar_plot + geom_point(data = pElemDat, aes_string(x="x", y = "freq"),
+    Main_bar_plot <- (Main_bar_plot + geom_point(data = pElemDat, aes(x = .data[["x"]], y = .data[["freq"]]),
                                                  position = position_jitter(width = 0.2, height = 0.2),
                                                  colour = pElemDat$color, size = 2, shape = 17))
   }

--- a/R/MainBar.R
+++ b/R/MainBar.R
@@ -128,11 +128,23 @@ Make_main_bar <- function(Main_bar_data, Q, show_num, ratios, customQ, number_an
                             axis.title.y = element_text(vjust = -0.8, size = 8.3*y_axis_title_scale), axis.text.y = element_text(vjust=0.3,
                                                                                                             size=7*y_axis_tick_label_scale)))
   if((show_num == "yes") || (show_num == "Yes")){
+    number_vjust <- number_hjust <- 0.5 # ggplot2 defaults
+    if(number_angles == 0) {
+      number_vjust <- -0.5
+    } else if(number_angles <= 45) {
+      number_vjust <- -0.5
+      number_hjust <- 0
+    } else if(number_angles <= 90) {
+      number_vjust <- 0.5
+      number_hjust <- -0.2
+    }
     if(is.null(number.colors)) {
-      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale, vjust = -1,
+      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale,
+						  vjust = number_vjust, hjust = number_hjust,
                                                   angle = number_angles, colour = Main_bar_data$color))
     } else {
-      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale, vjust = -1,
+      Main_bar_plot <- (Main_bar_plot + geom_text(aes_string(label = "freq"), size = 2.2*intersection_size_number_scale,
+						  vjust = number_vjust, hjust = number_hjust,
                                                   angle = number_angles, colour = number.colors))
     }
   }

--- a/R/Matrix.R
+++ b/R/Matrix.R
@@ -99,13 +99,13 @@ Make_matrix_plot <- function(Mat_data,Set_size_data, Main_bar_data, point_size, 
                                        limits = c(0.5,(nrow(Set_size_data) +0.5)),
                                        labels = labels, expand = c(0,0))
                   + scale_x_continuous(limits = c(0,(nrow(Main_bar_data)+1 )), expand = c(0,0))
-                  + geom_rect(data = shading_data, aes_string(xmin = "min", xmax = "max",
-                                                              ymin = "y_min", ymax = "y_max"),
+                  + geom_rect(data = shading_data, aes(xmin = .data[["min"]], xmax = .data[["max"]],
+                                                       ymin = .data[["y_min"]], ymax = .data[["y_max"]]),
                               fill = shading_data$shade_color, alpha = shade_alpha)
-                  + geom_point(data= Mat_data, aes_string(x= "x", y= "y"), colour = Mat_data$color,
+                  + geom_point(data= Mat_data, aes(x =  .data[["x"]], y = .data[["y"]]), colour = Mat_data$color,
                                size= point_size, alpha = Mat_data$alpha, shape=16)
-                  + geom_line(data= Mat_data, aes_string(group = "Intersection", x="x", y="y",
-                                                         colour = "color"), size = line_size)
+                  + geom_line(data= Mat_data, aes(group = .data[["Intersection"]], x = .data[["x"]], y = .data[["y"]],
+                                                  colour = .data[["color"]]), linewidth = line_size)
                   + scale_color_identity())
   Matrix_plot <- ggplot_gtable(ggplot_build(Matrix_plot))
   return(Matrix_plot)

--- a/R/Metadata.plots.R
+++ b/R/Metadata.plots.R
@@ -16,8 +16,8 @@ metadataHist <- function(metadata, y_data, colors){
   }
   
   plot <- (ggplot(data=metadata)
-           + geom_bar(aes_string(x="sets", y=y_data),
-                      stat="identity", position="identity", width = 0.4,
+           + geom_bar(aes(x = .data[["sets"]], y = .data[[y_data]]),
+                      stat = "identity", position = "identity", width = 0.4,
                       fill = colors)
            + scale_x_continuous(limits = c(0.5, (nrow(metadata)+0.5)),
                                 breaks = c(0, max(metadata)),
@@ -28,7 +28,7 @@ metadataHist <- function(metadata, y_data, colors){
                    axis.text.x = element_text(size = 7),
                    axis.line = element_line(colour = "gray0"),
                    axis.line.y = element_blank(),
-                   axis.line.x = element_line(colour = "gray0", size = 0.3),
+                   axis.line.x = element_line(colour = "gray0", linewidth = 0.3),
                    axis.text.y = element_blank(),
                    axis.ticks.y = element_blank(),
                    panel.grid.minor = element_blank(),
@@ -84,7 +84,7 @@ metadataHeat <- function(metadata, y_data, plot_type, colors){
     titleAdjustment <- 25
   #}
   
-  plot <- (ggplot(data=metadata, aes_string(x="sets", y = 1, fill = y_data))
+  plot <- (ggplot(data=metadata, aes(x = .data[["sets"]], y = 1, fill = .data[[y_data]]))
            + scale_x_continuous(expand = c(c(0,0), c(0,0)))
            + theme(panel.background = element_rect("white"),
                    plot.title = element_text(margin = margin(b=titleAdjustment),
@@ -167,7 +167,7 @@ metadataText <- function(metadata, y_data, colors, alignment){
   ncols <- ncol(metadata)
   metadata <- cbind(metadata, c(1:nrow(metadata)))
   names(metadata)[ncol(metadata)] <- "x"
-  plot <- (ggplot(data=metadata, aes_string(x="x", y=1, label = y_data, colour = y_data, size =10))
+  plot <- (ggplot(data=metadata, aes(x = .data[["x"]], y = 1, label = .data[[y_data]], colour = .data[[y_data]], size = 10))
            + scale_x_continuous(limits = c(0.5, (nrow(metadata)+0.5)),
                                 expand = c(0,0))
            + theme(panel.background = element_rect("white"),

--- a/R/Metadata.plots.R
+++ b/R/Metadata.plots.R
@@ -88,7 +88,7 @@ metadataHeat <- function(metadata, y_data, plot_type, colors){
            + scale_x_continuous(expand = c(c(0,0), c(0,0)))
            + theme(panel.background = element_rect("white"),
                    plot.title = element_text(margin = margin(b=titleAdjustment),
-                                             size = 9, hjust = 0.5),
+                                             size = 9, hjust = 0.5, vjust = 0.75),
                    plot.margin=unit(c(0,0,0,0), "lines"),
                    axis.title.x = element_text(size = 8.3),
                    legend.position = "none",
@@ -172,7 +172,7 @@ metadataText <- function(metadata, y_data, colors, alignment){
                                 expand = c(0,0))
            + theme(panel.background = element_rect("white"),
                    plot.title = element_text(margin = margin(b=titleAdjustment),
-                                             size = 9, hjust = 0.5),
+                                             size = 9, hjust = 0.5, vjust = 0.75),
                    plot.margin=unit(c(0,0,0,0), "lines"),
                    axis.title.x = element_text(size = 7),
                    legend.position = "none",

--- a/R/SizeBar.R
+++ b/R/SizeBar.R
@@ -69,7 +69,7 @@ Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets
     num.size <- (7/2.845276)*x_axis_tick_label_scale
   }
   
-  Size_plot <- (ggplot(data = Set_size_data, aes_string(x ="x", y = "y"))
+  Size_plot <- (ggplot(data = Set_size_data, aes(x = .data[["x"]], y = .data[["y"]]))
                 + geom_bar(stat = "identity",colour = sbar_color, width = 0.4,
                            fill = sbar_color, position = "identity")
                 + scale_x_continuous(limits = c(0.5, (nrow(Set_size_data) + 0.5)),
@@ -82,7 +82,7 @@ Make_size_plot <- function(Set_size_data, sbar_color, ratios, ylabel, scale_sets
                                                    vjust = 1, hjust = 0.5),
                         axis.line = element_line(colour = "gray0"),
                         axis.line.y = element_blank(),
-                        axis.line.x = element_line(colour = "gray0", size = 0.3),
+                        axis.line.x = element_line(colour = "gray0", linewidth = 0.3),
                         axis.text.y = element_blank(),
                         axis.ticks.y = element_blank(),
                         panel.grid.minor = element_blank(),

--- a/R/histogram.R
+++ b/R/histogram.R
@@ -6,16 +6,16 @@
 #' @note See examples section for upset function on how to use custom.plot parameter
 #' @export
 histogram <- function(mydata, x){
-  att_plot <- (ggplot(data = mydata, aes_string(x = x, fill = "color")) 
-               + scale_fill_identity()
-               + geom_histogram(binwidth = 1)
-               + ylab("Frequency")
-               + theme(panel.background = element_rect(fill = "white"),
-                       plot.title = element_text(vjust = 1.5),
-                       panel.border = element_blank(),
-                       panel.grid.minor = element_blank(),
-                       panel.grid.major = element_blank(),
-                       axis.title.y = element_text(vjust = 1.3, size = 8.3),
-                       axis.title.x = element_text(size = 8.3),
-                       plot.margin=unit(c(0.5,0,0,1), "cm")))
+  att_plot <- (ggplot(data = mydata, aes(x = .data[[x]], fill = .data[["color"]])) +
+               scale_fill_identity() +
+               geom_histogram(binwidth = 1) +
+               ylab("Frequency") +
+               theme(panel.background = element_rect(fill = "white"),
+                     plot.title = element_text(vjust = 1.5),
+                     panel.border = element_blank(),
+                     panel.grid.minor = element_blank(),
+                     panel.grid.major = element_blank(),
+                     axis.title.y = element_text(vjust = 1.3, size = 8.3),
+                     axis.title.x = element_text(size = 8.3),
+                     plot.margin=unit(c(0.5,0,0,1), "cm")))
 }

--- a/R/scatter_plot.R
+++ b/R/scatter_plot.R
@@ -7,13 +7,13 @@
 #' @note See examples section for upset function on how to use custom.plot parameter.
 #' @export
 scatter_plot <- function(mydata, x, y){
-  att_plot <- (ggplot(data = mydata, aes_string(x = x, y = y, colour = "color"))
-               + geom_point(shape=16) + scale_color_identity()
-               + theme(panel.background = element_rect(fill = "white"),
-                       plot.title = element_text(vjust = 1.3),
-                       panel.grid.minor = element_blank(),
-                       panel.grid.major = element_blank(),
-                       axis.title.y = element_text(vjust = 1.3, size = 8.3),
-                       axis.title.x = element_text(size = 8.3),
-                       plot.margin=unit(c(0.5,0,0,1), "cm")))
+  att_plot <- (ggplot(data = mydata, aes(x = .data[[x]], y = .data[[y]], colour = .data[["color"]])) +
+               geom_point(shape=16) + scale_color_identity() +
+               theme(panel.background = element_rect(fill = "white"),
+                     plot.title = element_text(vjust = 1.3),
+                     panel.grid.minor = element_blank(),
+                     panel.grid.major = element_blank(),
+                     axis.title.y = element_text(vjust = 1.3, size = 8.3),
+                     axis.title.x = element_text(size = 8.3),
+                     plot.margin=unit(c(0.5,0,0,1), "cm")))
 }

--- a/R/upset.R
+++ b/R/upset.R
@@ -78,13 +78,13 @@
 #' }
 #'
 #' plot1 <- function(mydata, x){
-#'   myplot <- (ggplot(mydata, aes_string(x= x, fill = "color"))
+#'   myplot <- (ggplot(mydata, aes(x = .data[[x]], fill = "color"))
 #'             + geom_histogram() + scale_fill_identity()
 #'             + theme(plot.margin = unit(c(0,0,0,0), "cm")))
 #' }
 #'
 #' plot2 <- function(mydata, x, y){
-#'   myplot <- (ggplot(data = mydata, aes_string(x=x, y=y, colour = "color"), alpha = 0.5)
+#'   myplot <- (ggplot(data = mydata, aes(x = .data[[x]], y = .data[[y]], colour = "color"), alpha = 0.5)
 #'             + geom_point() + scale_color_identity()
 #'             + theme_bw() + theme(plot.margin = unit(c(0,0,0,0), "cm")))
 #' }


### PR DESCRIPTION
This PR makes the following changes to the current code base

1. When using `number.angles` to specify the rotation of the number labels above the bars, angles between 0 and 90 will now place the number in a better position visually [#70, #78, #133]
2. `vjust` is used to increase the set title (as specify by `column`) above the heatmap when incorporating set metadata
3. `plot_lims` is changed to factor to that the boxplot can be properly aligned [#195]
4. changes were makde to replace the deprecated `aes_string` function and wrong use of `size` to specify line widths [#270]

---

On [1], these are the plots before the changes

``` r
upset(movies, number.angles = 0)
``` 
<img width="576" height="384" alt="actual-reprex-code-1" src="https://github.com/user-attachments/assets/9d20406d-e426-49f8-bbd5-89bf02ff5255" />


``` r
upset(movies, number.angles = 45)
``` 
<img width="576" height="384" alt="actual-reprex-code-2" src="https://github.com/user-attachments/assets/ebc77626-efd3-4693-9274-9107761c1160" />


``` r
upset(movies, number.angles = 90)
``` 
<img width="576" height="384" alt="actual-reprex-code-3" src="https://github.com/user-attachments/assets/da1a12c8-8a09-4d60-831e-4a7864c66a6b" />

---

On [1], these are the plots after the changes

``` r
upset(movies, number.angles = 0)
``` 
<img width="576" height="384" alt="actual-reprex-code-1" src="https://github.com/user-attachments/assets/2ebde0c7-1817-427b-8d9c-ce937d7b116c" />

``` r
upset(movies, number.angles = 45)
``` 
<img width="576" height="384" alt="actual-reprex-code-2" src="https://github.com/user-attachments/assets/61a3e2e1-4706-4747-b2f9-8f51420df5e3" />

``` r
upset(movies, number.angles = 90)
``` 
<img width="576" height="384" alt="actual-reprex-code-3" src="https://github.com/user-attachments/assets/ee9eddbb-41cb-4eea-a50f-f453a73b46c5" />

