### PR TITLE
add rownames to data in fromList.R

### DIFF
--- a/R/fromList.R
+++ b/R/fromList.R
@@ -9,6 +9,7 @@ fromList <- function(input){
   data <- unlist(lapply(input, function(x){x <- as.vector(match(elements, x))}))
   data[is.na(data)] <- as.integer(0); data[data != 0] <- as.integer(1)
   data <- data.frame(matrix(data, ncol = length(input), byrow = F))
+  rownames(data) <- elements
   data <- data[which(rowSums(data) !=0), ]
   names(data) <- names(input)
   return(data)


### PR DESCRIPTION
A common request seems to be to work with the sets generated by the package. Adding `rownames` to `data` in the fromList.R script is a simple change that can facilitate this task, as users can know which elements are present in each set for downstream analysis.

Small example:
```R
listInput <- list(one = c(1, 2, 3, 5, 7, 8, 11, 12, 13), 
                  two = c(1, 2, 4, 5, 10), 
                  three = c(1, 5, 6, 7, 8, 9, 10, 12, 13))

df <- fromList(listInput) 
# E.g., elements present in sets one and three, but not in two
rownames(df[df$one == 1 & df$two == 0 & df$three == 1,])
# [1] "7"  "8"  "12" "13"
```


